### PR TITLE
make data folder in .gitignore case insensitive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
-data/
+[dD]ata/


### PR DESCRIPTION
It is a good practice to never expose the data which you use for the projects. I kwow this data is publicly available but it would be nice to keep good practices here 